### PR TITLE
Remove ring around activated glowpad targets.

### DIFF
--- a/res/drawable/ic_lockscreen_answer_activated_layer.xml
+++ b/res/drawable/ic_lockscreen_answer_activated_layer.xml
@@ -14,15 +14,19 @@
      limitations under the License.
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-
     <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="@dimen/incoming_call_widget_ring_inner_radius"
-            android:thickness="@dimen/incoming_call_widget_ring_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_activated_ring"/>
+        <shape android:shape="oval">
+            <solid android:color="@color/incoming_call_answer_circle" />
+            <size
+                android:width="@dimen/incoming_call_widget_circle_size"
+                android:height="@dimen/incoming_call_widget_circle_size" />
         </shape>
     </item>
-    <item android:drawable="@drawable/ic_lockscreen_answer_normal_layer" />
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/ic_call_white_24dp"
+            android:tint="@color/incoming_call_widget_bitmap"
+            android:autoMirrored="true" />
+    </item>
 </layer-list>

--- a/res/drawable/ic_lockscreen_answer_end_current_activated_layer.xml
+++ b/res/drawable/ic_lockscreen_answer_end_current_activated_layer.xml
@@ -15,14 +15,6 @@
      limitations under the License.
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="@dimen/incoming_call_widget_ring_inner_radius"
-            android:thickness="@dimen/incoming_call_widget_ring_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_activated_ring"/>
-        </shape>
-    </item>
-    <item android:drawable="@drawable/ic_lockscreen_answer_end_current_normal_layer" />
+    <item android:drawable="@drawable/ic_lockscreen_answer_activated_layer" />
+    <item android:drawable="@drawable/ic_lockscreen_decline_small_layer" />
 </layer-list>

--- a/res/drawable/ic_lockscreen_answer_end_current_normal_layer.xml
+++ b/res/drawable/ic_lockscreen_answer_end_current_normal_layer.xml
@@ -15,23 +15,14 @@
      limitations under the License.
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="0dp"
-            android:thickness="@dimen/incoming_call_widget_circle_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_answer_circle"/>
-        </shape>
-    </item>
-    <item>
+    <item android:drawable="@drawable/ic_lockscreen_answer_normal_layer" />
+    <item
+        android:top="@dimen/incoming_call_widget_small_circle_top_offset"
+        android:left="@dimen/incoming_call_widget_small_circle_left_offset">
         <bitmap
             android:gravity="center"
-            android:src="@drawable/ic_call_white_24dp"
+            android:src="@drawable/ic_call_end_16dp"
             android:tint="@color/incoming_call_widget_bitmap"
             android:autoMirrored="true" />
     </item>
-    <item   android:top="@dimen/incoming_call_widget_small_circle_top_offset"
-            android:left="@dimen/incoming_call_widget_small_circle_left_offset"
-            android:drawable="@drawable/ic_lockscreen_decline_small_layer" />
 </layer-list>

--- a/res/drawable/ic_lockscreen_answer_hold_current_activated_layer.xml
+++ b/res/drawable/ic_lockscreen_answer_hold_current_activated_layer.xml
@@ -15,14 +15,6 @@
      limitations under the License.
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="@dimen/incoming_call_widget_ring_inner_radius"
-            android:thickness="@dimen/incoming_call_widget_ring_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_activated_ring"/>
-        </shape>
-    </item>
-    <item android:drawable="@drawable/ic_lockscreen_answer_hold_current_normal_layer" />
+    <item android:drawable="@drawable/ic_lockscreen_answer_activated_layer" />
+    <item android:drawable="@drawable/ic_lockscreen_hold_small_layer" />
 </layer-list>

--- a/res/drawable/ic_lockscreen_answer_hold_current_normal_layer.xml
+++ b/res/drawable/ic_lockscreen_answer_hold_current_normal_layer.xml
@@ -15,23 +15,14 @@
      limitations under the License.
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="0dp"
-            android:thickness="@dimen/incoming_call_widget_circle_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_answer_circle"/>
-        </shape>
-    </item>
-    <item>
+    <item android:drawable="@drawable/ic_lockscreen_answer_normal_layer" />
+    <item
+        android:top="@dimen/incoming_call_widget_small_circle_top_offset"
+        android:left="@dimen/incoming_call_widget_small_circle_left_offset">
         <bitmap
             android:gravity="center"
-            android:src="@drawable/ic_call_white_24dp"
+            android:src="@drawable/ic_pause_16dp"
             android:tint="@color/incoming_call_widget_bitmap"
             android:autoMirrored="true" />
     </item>
-    <item   android:top="@dimen/incoming_call_widget_small_circle_top_offset"
-            android:left="@dimen/incoming_call_widget_small_circle_left_offset"
-            android:drawable="@drawable/ic_lockscreen_hold_small_layer" />
 </layer-list>

--- a/res/drawable/ic_lockscreen_answer_normal_layer.xml
+++ b/res/drawable/ic_lockscreen_answer_normal_layer.xml
@@ -15,19 +15,19 @@
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="0dp"
-            android:thickness="@dimen/incoming_call_widget_circle_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_answer_circle"/>
+        <!-- A fake circle to fix the size of this layer asset. -->
+        <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
+            <size
+                android:width="@dimen/incoming_call_widget_circle_size"
+                android:height="@dimen/incoming_call_widget_circle_size" />
         </shape>
     </item>
     <item>
         <bitmap
             android:gravity="center"
             android:src="@drawable/ic_call_white_24dp"
-            android:tint="@color/incoming_call_widget_bitmap"
+            android:tint="@color/incoming_call_answer_circle"
             android:autoMirrored="true" />
     </item>
 </layer-list>

--- a/res/drawable/ic_lockscreen_block_activated_layer.xml
+++ b/res/drawable/ic_lockscreen_block_activated_layer.xml
@@ -15,13 +15,22 @@
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="@dimen/incoming_call_widget_ring_inner_radius"
-            android:thickness="@dimen/incoming_call_widget_ring_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_activated_ring"/>
+        <shape android:shape="oval">
+            <solid android:color="@color/incoming_call_secondary_action_circle" />
+            <size
+                android:width="@dimen/incoming_call_widget_circle_size"
+                android:height="@dimen/incoming_call_widget_circle_size" />
         </shape>
     </item>
-    <item android:drawable="@drawable/ic_lockscreen_block_normal_layer" />
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/ic_do_not_disturb_alt_white_24dp"
+            android:tint="@color/incoming_call_widget_bitmap"
+            android:autoMirrored="true" />
+    </item>
+    <item
+        android:top="@dimen/incoming_call_widget_small_circle_top_offset"
+        android:left="@dimen/incoming_call_widget_small_circle_left_offset"
+        android:drawable="@drawable/ic_lockscreen_decline_small_layer" />
 </layer-list>

--- a/res/drawable/ic_lockscreen_block_normal_layer.xml
+++ b/res/drawable/ic_lockscreen_block_normal_layer.xml
@@ -16,12 +16,12 @@
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="0dp"
-            android:thickness="@dimen/incoming_call_widget_circle_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_sms_circle"/>
+        <!-- A fake circle to fix the size of this layer asset. -->
+        <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
+            <size
+                android:width="@dimen/incoming_call_widget_circle_size"
+                android:height="@dimen/incoming_call_widget_circle_size" />
         </shape>
     </item>
     <item>
@@ -31,7 +31,4 @@
             android:tint="@color/incoming_call_widget_bitmap"
             android:autoMirrored="true" />
     </item>
-    <item   android:top="@dimen/incoming_call_widget_small_circle_top_offset"
-            android:left="@dimen/incoming_call_widget_small_circle_left_offset"
-            android:drawable="@drawable/ic_lockscreen_decline_small_layer" />
 </layer-list>

--- a/res/drawable/ic_lockscreen_decline_activated_layer.xml
+++ b/res/drawable/ic_lockscreen_decline_activated_layer.xml
@@ -15,13 +15,18 @@
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="@dimen/incoming_call_widget_ring_inner_radius"
-            android:thickness="@dimen/incoming_call_widget_ring_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_activated_ring"/>
+        <shape android:shape="oval">
+            <solid android:color="@color/incoming_call_decline_circle" />
+            <size
+                android:width="@dimen/incoming_call_widget_circle_size"
+                android:height="@dimen/incoming_call_widget_circle_size" />
         </shape>
     </item>
-    <item android:drawable="@drawable/ic_lockscreen_decline_normal_layer" />
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/ic_call_end_white_24dp"
+            android:tint="@color/incoming_call_widget_bitmap"
+            android:autoMirrored="true" />
+    </item>
 </layer-list>

--- a/res/drawable/ic_lockscreen_decline_normal_layer.xml
+++ b/res/drawable/ic_lockscreen_decline_normal_layer.xml
@@ -15,19 +15,19 @@
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="0dp"
-            android:thickness="@dimen/incoming_call_widget_circle_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_decline_circle"/>
+        <!-- A fake circle to fix the size of this layer asset. -->
+        <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
+            <size
+                android:width="@dimen/incoming_call_widget_circle_size"
+                android:height="@dimen/incoming_call_widget_circle_size" />
         </shape>
     </item>
     <item>
         <bitmap
             android:gravity="center"
             android:src="@drawable/ic_call_end_white_24dp"
-            android:tint="@color/incoming_call_widget_bitmap"
+            android:tint="@color/incoming_call_decline_circle"
             android:autoMirrored="true" />
     </item>
 </layer-list>

--- a/res/drawable/ic_lockscreen_hold_small_layer.xml
+++ b/res/drawable/ic_lockscreen_hold_small_layer.xml
@@ -30,7 +30,7 @@
         <bitmap
             android:gravity="center"
             android:src="@drawable/ic_pause_16dp"
-            android:tint="@color/incoming_call_hold_bitmap"
+            android:tint="@color/incoming_call_widget_bitmap"
             android:autoMirrored="true" />
     </item>
 </layer-list>

--- a/res/drawable/ic_lockscreen_text_activated_layer.xml
+++ b/res/drawable/ic_lockscreen_text_activated_layer.xml
@@ -15,13 +15,18 @@
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="@dimen/incoming_call_widget_ring_inner_radius"
-            android:thickness="@dimen/incoming_call_widget_ring_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/glowpad_widget_active_color"/>
+        <shape android:shape="oval">
+            <solid android:color="@color/incoming_call_secondary_action_circle" />
+            <size
+                android:width="@dimen/incoming_call_widget_circle_size"
+                android:height="@dimen/incoming_call_widget_circle_size" />
         </shape>
     </item>
-    <item android:drawable="@drawable/ic_lockscreen_text_normal_layer" />
+    <item>
+        <bitmap
+            android:gravity="center"
+            android:src="@drawable/fab_ic_message"
+            android:tint="@color/incoming_call_widget_bitmap"
+            android:autoMirrored="true" />
+    </item>
 </layer-list>

--- a/res/drawable/ic_lockscreen_text_normal_layer.xml
+++ b/res/drawable/ic_lockscreen_text_normal_layer.xml
@@ -15,12 +15,12 @@
 -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape
-            android:shape="ring"
-            android:innerRadius="0dp"
-            android:thickness="@dimen/incoming_call_widget_circle_thickness"
-            android:useLevel="false">
-            <solid android:color="@color/incoming_call_sms_circle"/>
+        <!-- A fake circle to fix the size of this layer asset. -->
+        <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
+            <size
+                android:width="@dimen/incoming_call_widget_circle_size"
+                android:height="@dimen/incoming_call_widget_circle_size" />
         </shape>
     </item>
     <item>

--- a/res/values/cm_colors.xml
+++ b/res/values/cm_colors.xml
@@ -25,14 +25,12 @@
     <color name="contact_info_attribution_text_color">#ffffff</color>
 
     <color name="incoming_call_display_text">#b2ffffff</color>
-    <color name="incoming_call_answer_circle">#00c853</color>
-    <color name="incoming_call_decline_circle">#ff2844</color>
-    <color name="incoming_call_decline_small_circle">#ff2844</color>
-    <color name="incoming_call_activated_ring">#ffffff</color>
+    <color name="incoming_call_answer_circle">#4caf50</color>
+    <color name="incoming_call_decline_circle">#f44336</color>
+    <color name="incoming_call_decline_small_circle">#f44336</color>
     <color name="incoming_call_widget_bitmap">#ffffff</color>
     <color name="incoming_call_hold_small_circle">#607d8b</color>
-    <color name="incoming_call_hold_bitmap">#b2ffffff</color>
-    <color name="incoming_call_sms_circle">#0288d1</color>
+    <color name="incoming_call_secondary_action_circle">#03a9f4</color>
 
     <color name="mod_button_background_color">@color/dialer_theme_color_dark</color>
 </resources>


### PR DESCRIPTION
That ring doesn't really look material-ly. Go back to just showing the
colored icon in normal state and white icon on colored circle in
activated state.

Change-Id: I147e22e590a34c966aee9567f9ff549f6f957107
