### PR TITLE
GlowpadView: Properly scale ring for block option

### DIFF
--- a/src/com/android/incallui/widget/multiwaveview/GlowPadView.java
+++ b/src/com/android/incallui/widget/multiwaveview/GlowPadView.java
@@ -225,7 +225,7 @@ public class GlowPadView extends View {
     private boolean mAlwaysTrackFinger;
     private int mHorizontalInset;
     private int mVerticalInset;
-    private int mGravity = Gravity.TOP;
+    private int mGravity = Gravity.CENTER_VERTICAL | Gravity.CENTER_HORIZONTAL;
     private boolean mInitialLayout = true;
     private Tweener mBackgroundAnimator;
     private PointCloud mPointCloud;


### PR DESCRIPTION
On smaller screens with custom themes and software nav the
bottom target (Block) can be cut off by the navigation.

This sets our gravity to properly scale for a completely
centered ring.

Change-Id: I02f8bdc86ec4ae7ab95fe7b04a313b112cad2610
Ticket: CYNGNOS-3119
